### PR TITLE
add BOINC compatibility matrix and validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,46 @@ jobs:
 
       - name: Doc tests
         run: cargo test --doc --locked
+
+  host-matrix:
+    name: Host matrix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Tests
+        run: cargo test --locked
+
+  compatibility-matrix:
+    name: BOINC compatibility (${{ matrix.boinc_target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - boinc_target: 7.16
+            test_name: boinc_7_16_fixture_compatibility
+          - boinc_target: 7.20
+            test_name: boinc_7_20_fixture_compatibility
+          - boinc_target: 8.2
+            test_name: boinc_8_2_fixture_compatibility
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run compatibility fixture
+        run: cargo test --locked --test compatibility_matrix_tests ${{ matrix.test_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   reads it at startup and applies any keys not already set in the environment.
 - Accessibility and theming guidance in `README.md`, including keyboard-only
   navigation, `NO_COLOR` support, and current terminal-rendering constraints.
+- BOINC compatibility matrix documentation covering supported `7.16.x`, `7.20.x`,
+  and `8.2.x` validation targets, host OS guidance, and known quirks.
+- Release checklist with a compatibility sign-off gate for tagged releases.
+- Fixture-backed compatibility tests for BOINC `7.16`, `7.20`, and `8.2` parser
+  variants, plus dedicated GitHub Actions jobs for each supported target.
 
 ### Fixed
 - Corrected `compute_nonce_hash` doctest expected value.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ Thanks for helping improve `boincrs`.
 - Unit and integration:
   ```bash
   cargo test
+  cargo test --test compatibility_matrix_tests
   ```
 - Local BOINC daemon integration:
   ```bash
@@ -60,6 +61,10 @@ Thanks for helping improve `boincrs`.
   BOINCRS_ASTEROIDS_ACCOUNT_KEY='YOUR_ASTEROIDS_KEY' \
   cargo test --test live_beta_projects -- --ignored --nocapture
   ```
+
+If you touch BOINC protocol parsing, auth, transport, or refresh/controller behavior,
+refresh the compatibility fixtures under `tests/fixtures/compatibility/` and update
+`docs/compatibility-matrix.md` when support expectations change.
 
 ## Reporting bugs
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Binary: `./target/release/boincrs` (Linux/macOS) or `.\target\release\boincrs.ex
 **Linux:** install Rust and BOINC, then build as above.  
 **macOS / Windows:** install Rust and [BOINC](https://boinc.berkeley.edu/download.php), then the same clone/build steps.
 
+## Compatibility
+
+`boincrs` actively validates BOINC `7.16.x`, `7.20.x`, and `8.2.x`.
+See `docs/compatibility-matrix.md` for the supported BOINC/host OS matrix,
+automation coverage, manual validation steps, and known quirks.
+
+Maintainers should use `docs/release-checklist.md` before tagging a release; it
+includes the compatibility sign-off gate.
+
 ## Learn more
 
 | Topic | Link |
@@ -107,6 +116,7 @@ Known constraints:
 
 ```bash
 cargo test
+cargo test --test compatibility_matrix_tests
 ```
 
 **Against a live local BOINC daemon** (ignored tests — needs GUI RPC password):
@@ -156,4 +166,6 @@ Do not commit real `.env` values. Treat GUI RPC password and project authenticat
 - `docs/architecture/app-controller.md`
 - `docs/architecture/smoke-checklist.md`
 - `docs/architecture/beta-primegrid-asteroids.md`
+- `docs/compatibility-matrix.md`
+- `docs/release-checklist.md`
 - `docs/decisions/0001-error-handling.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@
 - ~~Improved project/task selection for all panes~~ ✓
 - ~~Exportable diagnostics bundle for bug reports~~ ✓
 - ~~Optional `.env` auto-loading without shell `source`~~ ✓
+- ~~BOINC compatibility matrix and validation gates~~ ✓
 
 ## Release Candidate
 
@@ -26,7 +27,6 @@
   - macOS signed/universal binaries
   - Windows executable + installer path
 - Backoff/reconnect and stronger error surfacing
-- Wider BOINC version compatibility validation
 - User-facing command docs and screenshots
 
 ## 1.0

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,0 +1,71 @@
+# BOINC Compatibility Matrix
+
+This document defines the BOINC client branches that `boincrs` actively validates.
+The matrix is about **GUI RPC compatibility for local clients**, not every historical
+BOINC installer that has ever existed upstream.
+
+## Supported targets
+
+| BOINC target | Typical host OS combinations | Validation status | Known notes |
+| --- | --- | --- | --- |
+| `7.16.x` | Legacy macOS `10.9`-`12.x` installs and older Windows/macOS hosts still pinned to `7.16` | Supported with fixture coverage and manual legacy-host smoke when BOINC-facing code changes | Older clients may require CA bundle updates to reach some projects; replies commonly use tags like `active_task_state`, `last_bytes_xferred`, and `error`. |
+| `7.20.x` | macOS `10.10`-`12.x` transition hosts that cannot move to `8.x` yet | Supported with fixture coverage and manual smoke on a matching macOS host when BOINC-facing code changes | Some replies expose app identity via `plan_class` and mode values under nested `<mode>` tags. |
+| `8.2.x` | Linux `x64`/`ARM64`, macOS `10.13+`, Windows `10/11` `x64` | Supported current branch with fixture coverage plus automated host-OS CI on Linux, macOS, and Windows | Upstream's current mainstream branch; `boincrs` validates GUI RPC behavior, not optional Docker/host packaging features. |
+
+## Automated validation
+
+Each supported BOINC branch has a dedicated fixture-backed compatibility test:
+
+- `cargo test --test compatibility_matrix_tests boinc_7_16_fixture_compatibility`
+- `cargo test --test compatibility_matrix_tests boinc_7_20_fixture_compatibility`
+- `cargo test --test compatibility_matrix_tests boinc_8_2_fixture_compatibility`
+
+Fixtures live under `tests/fixtures/compatibility/` and deliberately cover the parser
+fallbacks that vary across BOINC releases, including alternate task-state, transfer,
+application, and mode encodings.
+
+GitHub Actions also runs a host OS build/test matrix on:
+
+- `ubuntu-latest`
+- `macos-latest`
+- `windows-latest`
+
+That host matrix validates that `boincrs` itself still builds and passes tests on the
+common desktop environments used with local BOINC clients.
+
+## Manual validation
+
+Automation does not replace a live daemon check. Before a release:
+
+1. Install or launch the target BOINC client version on the intended host OS.
+2. Run the ignored live read-surface test:
+   ```bash
+   BOINCRS_PASSWORD_FILE=/path/to/gui_rpc_auth.cfg \
+     cargo test --test live_local_boinc -- --ignored --nocapture
+   ```
+3. Run `cargo run` and complete `docs/architecture/smoke-checklist.md`.
+4. Record the host OS, BOINC version, and outcome in the release sign-off notes.
+
+If the change touched BOINC protocol parsing, auth, transport, or controller refresh
+logic, repeat the live check on one legacy branch target (`7.16.x` or `7.20.x`) in
+addition to the current `8.2.x` branch.
+
+## Known limitations and quirks
+
+- `boincrs` currently supports **local** GUI RPC workflows. Remote profile management is
+  outside this compatibility matrix.
+- BOINC versions before `7.18` can need upstream certificate bundle fixes to contact
+  some projects; `boincrs` does not patch that at runtime.
+- GUI RPC password file locations vary by packaging and OS. Common examples are
+  `/etc/boinc-client/gui_rpc_auth.cfg` on Linux and BOINC-managed app data paths on
+  macOS or Windows installs.
+- New BOINC fields may appear without breaking `boincrs`, but missing or renamed fields
+  still need fixture updates before a new BOINC branch is promoted to "supported".
+
+## Maintenance
+
+When BOINC-facing behavior changes:
+
+1. Update or add fixtures under `tests/fixtures/compatibility/`.
+2. Keep this matrix in sync with the targets covered by CI.
+3. Update `README.md` and the release checklist if support policy changes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,42 @@
+# Release Checklist
+
+Use this checklist before publishing a `boincrs` release candidate or tagged release.
+
+## Compatibility Sign-Off Gate
+
+Do not ship a release until all of the following are true:
+
+- [ ] `ci`, `host-matrix`, and `compatibility-matrix` GitHub Actions jobs are green.
+- [ ] `docs/compatibility-matrix.md` still matches the BOINC branches we intend to support.
+- [ ] A live `8.2.x` BOINC daemon smoke has passed on at least one supported host OS.
+- [ ] If BOINC-facing code changed, a live legacy smoke (`7.16.x` or `7.20.x`) also passed.
+- [ ] `docs/architecture/smoke-checklist.md` was completed against the release candidate.
+- [ ] README and changelog entries mention any newly discovered compatibility limits or quirks.
+
+## Manual Sign-Off Record
+
+Capture the release sign-off in the PR description, release issue, or tag notes using a
+short record like this:
+
+```text
+Compatibility sign-off:
+- BOINC 8.2.x on <host OS>: PASS/FAIL
+- BOINC 7.20.x or 7.16.x on <host OS>: PASS/FAIL (required for BOINC-facing changes)
+- Smoke checklist: PASS/FAIL
+- Compatibility CI fixtures: PASS/FAIL
+```
+
+## Commands
+
+Current-branch live validation:
+
+```bash
+BOINCRS_PASSWORD_FILE=/path/to/gui_rpc_auth.cfg \
+  cargo test --test live_local_boinc -- --ignored --nocapture
+```
+
+Fixture compatibility checks:
+
+```bash
+cargo test --test compatibility_matrix_tests
+```

--- a/tests/compatibility_matrix_tests.rs
+++ b/tests/compatibility_matrix_tests.rs
@@ -1,0 +1,146 @@
+use boincrs::boinc::protocol::{
+    parse_cc_status, parse_projects, parse_tasks, parse_transfers, ParsedTaskStatus,
+};
+
+#[test]
+fn boinc_7_16_fixture_compatibility() {
+    let projects = parse_projects(include_str!(
+        "fixtures/compatibility/boinc_7_16/projects.xml"
+    ))
+    .expect("7.16 project fixture should parse");
+    let tasks = parse_tasks(include_str!("fixtures/compatibility/boinc_7_16/tasks.xml"))
+        .expect("7.16 task fixture should parse");
+    let transfers = parse_transfers(include_str!(
+        "fixtures/compatibility/boinc_7_16/transfers.xml"
+    ))
+    .expect("7.16 transfer fixture should parse");
+    let status = parse_cc_status(include_str!("fixtures/compatibility/boinc_7_16/status.xml"))
+        .expect("7.16 status fixture should parse");
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].name, "Legacy Science");
+    assert!(projects[0].dont_request_more_work);
+
+    let running = tasks
+        .iter()
+        .find(|task| task.name == "legacy_active")
+        .expect("expected legacy active task");
+    assert!(running.active_task);
+    assert_eq!(running.status, ParsedTaskStatus::Running);
+    assert_eq!(running.application.as_deref(), Some("legacy_intelx86"));
+    assert_eq!(running.checkpoint_cpu_time, Some(600.0));
+
+    let report = tasks
+        .iter()
+        .find(|task| task.name == "legacy_report")
+        .expect("expected legacy report task");
+    assert_eq!(report.status, ParsedTaskStatus::ReadyToReport);
+    assert_eq!(report.application.as_deref(), Some("app#701600"));
+    assert_eq!(report.exit_status, Some(193));
+
+    assert_eq!(transfers.len(), 1);
+    assert_eq!(transfers[0].bytes_xferred, Some(2048));
+    assert!(transfers[0].is_upload);
+    assert_eq!(
+        transfers[0].error_msg.as_deref(),
+        Some("temporary dns failure")
+    );
+
+    assert_eq!(status.network_mode.as_deref(), Some("1"));
+    assert_eq!(status.task_mode.as_deref(), Some("2"));
+    assert_eq!(status.gpu_mode.as_deref(), Some("3"));
+}
+
+#[test]
+fn boinc_7_20_fixture_compatibility() {
+    let projects = parse_projects(include_str!(
+        "fixtures/compatibility/boinc_7_20/projects.xml"
+    ))
+    .expect("7.20 project fixture should parse");
+    let tasks = parse_tasks(include_str!("fixtures/compatibility/boinc_7_20/tasks.xml"))
+        .expect("7.20 task fixture should parse");
+    let transfers = parse_transfers(include_str!(
+        "fixtures/compatibility/boinc_7_20/transfers.xml"
+    ))
+    .expect("7.20 transfer fixture should parse");
+    let status = parse_cc_status(include_str!("fixtures/compatibility/boinc_7_20/status.xml"))
+        .expect("7.20 status fixture should parse");
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].name, "Bridge Science");
+    assert!(projects[0].suspended_via_gui);
+
+    let running = tasks
+        .iter()
+        .find(|task| task.name == "mid_running")
+        .expect("expected 7.20 running task");
+    assert!(running.active_task);
+    assert_eq!(running.status, ParsedTaskStatus::Running);
+    assert_eq!(running.application.as_deref(), Some("opencl_nvidia"));
+
+    let waiting = tasks
+        .iter()
+        .find(|task| task.name == "mid_waiting")
+        .expect("expected 7.20 waiting task");
+    assert_eq!(waiting.status, ParsedTaskStatus::WaitingToRun);
+    assert_eq!(waiting.application.as_deref(), Some("cuda102"));
+
+    assert_eq!(transfers.len(), 1);
+    assert_eq!(transfers[0].status, "active");
+    assert_eq!(transfers[0].bytes_xferred, Some(4096));
+    assert!(transfers[0].is_upload);
+    assert_eq!(
+        transfers[0].error_msg.as_deref(),
+        Some("temporary http 500")
+    );
+
+    assert_eq!(status.network_mode.as_deref(), Some("1"));
+    assert_eq!(status.task_mode.as_deref(), Some("2"));
+    assert_eq!(status.gpu_mode.as_deref(), Some("3"));
+}
+
+#[test]
+fn boinc_8_2_fixture_compatibility() {
+    let projects = parse_projects(include_str!(
+        "fixtures/compatibility/boinc_8_2/projects.xml"
+    ))
+    .expect("8.2 project fixture should parse");
+    let tasks = parse_tasks(include_str!("fixtures/compatibility/boinc_8_2/tasks.xml"))
+        .expect("8.2 task fixture should parse");
+    let transfers = parse_transfers(include_str!(
+        "fixtures/compatibility/boinc_8_2/transfers.xml"
+    ))
+    .expect("8.2 transfer fixture should parse");
+    let status = parse_cc_status(include_str!("fixtures/compatibility/boinc_8_2/status.xml"))
+        .expect("8.2 status fixture should parse");
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].name, "Modern Science");
+    assert!(!projects[0].dont_request_more_work);
+
+    let running = tasks
+        .iter()
+        .find(|task| task.name == "modern_running")
+        .expect("expected 8.2 running task");
+    assert_eq!(running.status, ParsedTaskStatus::Running);
+    assert_eq!(running.application.as_deref(), Some("vbox64_mt"));
+    assert_eq!(running.received_time, Some(1_710_000_000.0));
+
+    let waiting = tasks
+        .iter()
+        .find(|task| task.name == "modern_waiting")
+        .expect("expected 8.2 waiting task");
+    assert_eq!(waiting.status, ParsedTaskStatus::WaitingToRun);
+    assert_eq!(waiting.application.as_deref(), Some("app#80209"));
+
+    assert_eq!(transfers.len(), 1);
+    assert_eq!(transfers[0].status, "downloading");
+    assert_eq!(transfers[0].nbytes, Some(16_384));
+    assert_eq!(transfers[0].bytes_xferred, Some(8_192));
+    assert!(!transfers[0].is_upload);
+    assert!(transfers[0].error_msg.is_none());
+
+    assert_eq!(status.network_mode.as_deref(), Some("1"));
+    assert_eq!(status.task_mode.as_deref(), Some("2"));
+    assert_eq!(status.gpu_mode.as_deref(), Some("3"));
+}

--- a/tests/fixtures/compatibility/boinc_7_16/projects.xml
+++ b/tests/fixtures/compatibility/boinc_7_16/projects.xml
@@ -1,0 +1,8 @@
+<boinc_gui_rpc_reply>
+  <project>
+    <master_url>https://legacy.example/boinc/</master_url>
+    <project_name>Legacy Science</project_name>
+    <suspended_via_gui>0</suspended_via_gui>
+    <dont_request_more_work>1</dont_request_more_work>
+  </project>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_16/status.xml
+++ b/tests/fixtures/compatibility/boinc_7_16/status.xml
@@ -1,0 +1,7 @@
+<boinc_gui_rpc_reply>
+  <network_mode>
+    <perm_mode>1</perm_mode>
+  </network_mode>
+  <task_mode>2</task_mode>
+  <gpu_mode>3</gpu_mode>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_16/tasks.xml
+++ b/tests/fixtures/compatibility/boinc_7_16/tasks.xml
@@ -1,0 +1,22 @@
+<boinc_gui_rpc_reply>
+  <result>
+    <project_url>https://legacy.example/boinc/</project_url>
+    <name>legacy_active</name>
+    <active_task_state>1</active_task_state>
+    <scheduler_state>1</scheduler_state>
+    <fraction_done>0.42</fraction_done>
+    <elapsed_time>1200</elapsed_time>
+    <estimated_cpu_time_remaining>800</estimated_cpu_time_remaining>
+    <report_deadline>1710000000</report_deadline>
+    <resources>legacy_intelx86</resources>
+    <checkpoint_cpu_time>600</checkpoint_cpu_time>
+    <received_time>1700000000</received_time>
+  </result>
+  <result>
+    <project_url>https://legacy.example/boinc/</project_url>
+    <name>legacy_report</name>
+    <ready_to_report></ready_to_report>
+    <app_version_num>701600</app_version_num>
+    <exit_status>193</exit_status>
+  </result>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_16/transfers.xml
+++ b/tests/fixtures/compatibility/boinc_7_16/transfers.xml
@@ -1,0 +1,12 @@
+<boinc_gui_rpc_reply>
+  <file_transfer>
+    <project_url>https://legacy.example/boinc/</project_url>
+    <name>legacy_upload.zip</name>
+    <status>upload_pending</status>
+    <nbytes>4096</nbytes>
+    <last_bytes_xferred>2048</last_bytes_xferred>
+    <xfer_speed>512</xfer_speed>
+    <generated_locally>1</generated_locally>
+    <error>temporary dns failure</error>
+  </file_transfer>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_20/projects.xml
+++ b/tests/fixtures/compatibility/boinc_7_20/projects.xml
@@ -1,0 +1,8 @@
+<boinc_gui_rpc_reply>
+  <project>
+    <master_url>https://mid.example/boinc/</master_url>
+    <project_name>Bridge Science</project_name>
+    <suspended_via_gui>1</suspended_via_gui>
+    <dont_request_more_work>0</dont_request_more_work>
+  </project>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_20/status.xml
+++ b/tests/fixtures/compatibility/boinc_7_20/status.xml
@@ -1,0 +1,11 @@
+<boinc_gui_rpc_reply>
+  <network_mode>
+    <mode>1</mode>
+  </network_mode>
+  <task_mode>
+    <mode>2</mode>
+  </task_mode>
+  <gpu_mode>
+    <mode>3</mode>
+  </gpu_mode>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_20/tasks.xml
+++ b/tests/fixtures/compatibility/boinc_7_20/tasks.xml
@@ -1,0 +1,18 @@
+<boinc_gui_rpc_reply>
+  <result>
+    <project_url>https://mid.example/boinc/</project_url>
+    <name>mid_running</name>
+    <active_task>1</active_task>
+    <fraction_done>0.33</fraction_done>
+    <elapsed_time>900</elapsed_time>
+    <estimated_cpu_time_remaining>1800</estimated_cpu_time_remaining>
+    <plan_class>opencl_nvidia</plan_class>
+  </result>
+  <result>
+    <project_url>https://mid.example/boinc/</project_url>
+    <name>mid_waiting</name>
+    <scheduler_state>waiting to run</scheduler_state>
+    <plan_class>cuda102</plan_class>
+    <fraction_done>0.05</fraction_done>
+  </result>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_7_20/transfers.xml
+++ b/tests/fixtures/compatibility/boinc_7_20/transfers.xml
@@ -1,0 +1,12 @@
+<boinc_gui_rpc_reply>
+  <file_transfer>
+    <project_url>https://mid.example/boinc/</project_url>
+    <name>mid_upload.zip</name>
+    <status>active</status>
+    <nbytes>8192</nbytes>
+    <bytes_xferred>4096</bytes_xferred>
+    <xfer_speed>1280</xfer_speed>
+    <is_upload>1</is_upload>
+    <error_msg>temporary http 500</error_msg>
+  </file_transfer>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_8_2/projects.xml
+++ b/tests/fixtures/compatibility/boinc_8_2/projects.xml
@@ -1,0 +1,8 @@
+<boinc_gui_rpc_reply>
+  <project>
+    <master_url>https://modern.example/boinc/</master_url>
+    <project_name>Modern Science</project_name>
+    <suspended_via_gui>0</suspended_via_gui>
+    <dont_request_more_work>0</dont_request_more_work>
+  </project>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_8_2/status.xml
+++ b/tests/fixtures/compatibility/boinc_8_2/status.xml
@@ -1,0 +1,9 @@
+<boinc_gui_rpc_reply>
+  <network_mode>1</network_mode>
+  <task_mode>
+    <perm_mode>2</perm_mode>
+  </task_mode>
+  <gpu_mode>
+    <perm_mode>3</perm_mode>
+  </gpu_mode>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_8_2/tasks.xml
+++ b/tests/fixtures/compatibility/boinc_8_2/tasks.xml
@@ -1,0 +1,20 @@
+<boinc_gui_rpc_reply>
+  <result>
+    <project_url>https://modern.example/boinc/</project_url>
+    <name>modern_running</name>
+    <active_task>1</active_task>
+    <fraction_done>0.87</fraction_done>
+    <elapsed_time>7200</elapsed_time>
+    <estimated_cpu_time_remaining>900</estimated_cpu_time_remaining>
+    <report_deadline>1720000000</report_deadline>
+    <resources>vbox64_mt</resources>
+    <checkpoint_cpu_time>7100</checkpoint_cpu_time>
+    <received_time>1710000000</received_time>
+  </result>
+  <result>
+    <project_url>https://modern.example/boinc/</project_url>
+    <name>modern_waiting</name>
+    <scheduler_state>preempted</scheduler_state>
+    <app_version_num>80209</app_version_num>
+  </result>
+</boinc_gui_rpc_reply>

--- a/tests/fixtures/compatibility/boinc_8_2/transfers.xml
+++ b/tests/fixtures/compatibility/boinc_8_2/transfers.xml
@@ -1,0 +1,10 @@
+<boinc_gui_rpc_reply>
+  <file_transfer>
+    <project_url>https://modern.example/boinc/</project_url>
+    <name>modern_download.dat</name>
+    <status>downloading</status>
+    <nbytes>16384</nbytes>
+    <bytes_xferred>8192</bytes_xferred>
+    <xfer_speed>2048</xfer_speed>
+  </file_transfer>
+</boinc_gui_rpc_reply>


### PR DESCRIPTION
Document supported BOINC/client OS targets, add fixture-backed compatibility checks for each supported BOINC branch, and require release-time compatibility sign-off.