### PR TITLE
add project attach templates and preset profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,17 @@
 BOINCRS_ENDPOINT=127.0.0.1:31416
 BOINCRS_PASSWORD_FILE=/etc/boinc-client/gui_rpc_auth.cfg
+
+# Legacy per-project convenience keys (still supported).
 BOINCRS_PRIMEGRID_ACCOUNT_KEY=PUT_PRIMEGRID_AUTHENTICATOR_HERE
 BOINCRS_ASTEROIDS_ACCOUNT_KEY=PUT_ASTEROIDS_AUTHENTICATOR_HERE
+
+# Attach extra projects by template slug. Semicolon-delimited `slug|account_key` pairs.
+# Known slugs: asteroids, einstein, gpugrid, lhc, milkyway, primegrid,
+# rosetta, seti, worldcommunitygrid, yoyo. See docs/architecture/project-templates-and-profiles.md.
+#BOINCRS_ATTACH_TEMPLATES=rosetta|KEY_A;einstein|KEY_B
+
+# Legacy free-form list: semicolon-delimited `url|account_key` pairs.
+#BOINCRS_ATTACH_PROJECTS=https://boinc.example.org/|KEY_C
+
+# Preset profile file. Bundles attach entries plus CPU/network/GPU run modes.
+#BOINCRS_PROFILE_FILE=./boincrs.profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+- **Project attach templates**: curated registry of well-known BOINC projects
+  (`asteroids`, `einstein`, `gpugrid`, `lhc`, `milkyway`, `primegrid`,
+  `rosetta`, `seti`, `worldcommunitygrid`, `yoyo`) with canonical master URLs,
+  summaries, and category tags. Users can attach by slug via
+  `BOINCRS_ATTACH_TEMPLATES=slug|key;...` without memorizing project URLs.
+  Unknown slugs yield a clear error listing every known option.
+- **Preset profiles**: new `key = value` profile format bundling attach
+  entries plus CPU/network/GPU run-mode overrides. Load via
+  `BOINCRS_PROFILE_FILE=...`. Every validation error reports the offending
+  line number and key; unknown keys are rejected to prevent silent
+  mis-configuration.
+- Input validation for project URLs (scheme, host, whitespace) and profile
+  names (ASCII alphanumeric, `-`, `_`), surfaced as `AppError::Config` so
+  startup failures are distinguishable from transient RPC errors.
+- `BootstrapReport` returned from `attach_projects_from_env`, summarizing
+  attached URLs, skipped entries with reasons, and which run-mode overrides
+  were applied from the active profile.
+- Architecture note `docs/architecture/project-templates-and-profiles.md`
+  documenting the registry, profile schema, and startup flow.
 - Reconnect backoff: transient RPC failures now trigger bounded exponential backoff
   (1 s → 30 s, ±25% jitter) rather than a hard crash or silent stall. The daemon
   connection is automatically re-established when the daemon returns.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ set -a && source .env && set +a   # Linux/macOS
 
 With `BOINCRS_PRIMEGRID_ACCOUNT_KEY` / `BOINCRS_ASTEROIDS_ACCOUNT_KEY` set, startup runs `project_attach` then `project_update` for those projects.
 
+### Project templates and preset profiles
+
+`boincrs` ships a curated registry of well-known BOINC projects so you can attach them by **slug** rather than memorizing each master URL. Known slugs: `asteroids`, `einstein`, `gpugrid`, `lhc`, `milkyway`, `primegrid`, `rosetta`, `seti`, `worldcommunitygrid`, `yoyo`.
+
+Attach by template via `BOINCRS_ATTACH_TEMPLATES` (semicolon-delimited `slug|account_key`):
+
+```bash
+export BOINCRS_ATTACH_TEMPLATES='rosetta|ACCOUNT_KEY_A;einstein|ACCOUNT_KEY_B'
+```
+
+For repeatable setups, use a **preset profile** file (`key = value` format) and point `BOINCRS_PROFILE_FILE` at it:
+
+```ini
+# boincrs.profile
+name = desktop
+run_mode = auto
+network_mode = auto
+gpu_mode = never
+attach = primegrid|ACCOUNT_KEY_A
+attach = rosetta|ACCOUNT_KEY_B
+```
+
+Invalid slugs, URLs, or mode values are rejected with line-level validation errors so you see exactly what to fix. See [`docs/architecture/project-templates-and-profiles.md`](docs/architecture/project-templates-and-profiles.md) for the full schema.
+
 ### Run
 
 ```bash
@@ -166,6 +190,7 @@ Do not commit real `.env` values. Treat GUI RPC password and project authenticat
 - `docs/architecture/app-controller.md`
 - `docs/architecture/smoke-checklist.md`
 - `docs/architecture/beta-primegrid-asteroids.md`
+- `docs/architecture/project-templates-and-profiles.md`
 - `docs/compatibility-matrix.md`
 - `docs/release-checklist.md`
 - `docs/decisions/0001-error-handling.md`

--- a/docs/architecture/beta-primegrid-asteroids.md
+++ b/docs/architecture/beta-primegrid-asteroids.md
@@ -8,6 +8,10 @@
 - `BOINCRS_ASTEROIDS_ACCOUNT_KEY`: Asteroids@home account key
 - `BOINCRS_ATTACH_PROJECTS`: optional custom list in the form:
   - `https://example.com/boinc/|account_key;https://example2.com/|account_key2`
+- `BOINCRS_ATTACH_TEMPLATES`: curated-slug list, e.g. `primegrid|KEY1;rosetta|KEY2`
+  (see `docs/architecture/project-templates-and-profiles.md`).
+- `BOINCRS_PROFILE_FILE`: path to a preset profile bundling attach entries
+  and CPU/network/GPU mode overrides.
 
 When any of these are provided, startup performs:
 1. `project_attach`

--- a/docs/architecture/project-templates-and-profiles.md
+++ b/docs/architecture/project-templates-and-profiles.md
@@ -1,0 +1,94 @@
+# Project attach templates and preset profiles
+
+`boincrs` ships with two cooperating onboarding primitives:
+
+1. **Project templates** — a curated registry of well-known BOINC projects
+   mapping a short **slug** (e.g. `primegrid`) to a canonical master URL and
+   metadata.
+2. **Preset profiles** — a small persisted document that bundles attach
+   requests and run/network/GPU mode overrides, so returning users can
+   re-apply a known-good setup in one place.
+
+Both live in `src/boinc/`:
+
+| File | Purpose |
+| --- | --- |
+| `src/boinc/templates.rs` | In-memory registry, slug lookup, URL validation |
+| `src/boinc/profiles.rs` | Parse / format / load / save preset profiles |
+| `src/boinc/bootstrap.rs` | Applies env vars + profile to a live RPC client |
+
+## Template registry
+
+`boincrs::boinc::templates::all_templates()` returns the curated list. Each
+entry has a `slug`, human `name`, canonical `url`, short `summary`, and a set
+of `categories` (e.g. `astronomy`, `biology`).
+
+Current slugs: `asteroids`, `einstein`, `gpugrid`, `lhc`, `milkyway`,
+`primegrid`, `rosetta`, `seti`, `worldcommunitygrid`, `yoyo`.
+
+Resolution is performed by `resolve_template(input)` which accepts either a
+slug **or** a fully qualified URL. Invalid inputs produce a `TemplateError`
+with a human-readable hint (including the full list of known slugs when a
+slug cannot be resolved).
+
+## Preset profile format
+
+Profiles are a tiny `key = value` text format — no new dependencies.
+
+```
+# boincrs profile: desktop
+name = desktop
+run_mode = auto
+network_mode = auto
+gpu_mode = never
+attach = primegrid|ACCOUNT_KEY_A
+attach = rosetta|ACCOUNT_KEY_B
+attach = https://boinc.example.org/custom/|ACCOUNT_KEY_C
+```
+
+Recognized keys:
+
+| Key | Required | Notes |
+| --- | --- | --- |
+| `name` | yes | ASCII letters, digits, `-`, `_` |
+| `run_mode` | no | `always` \| `auto` \| `never` |
+| `network_mode` | no | `always` \| `auto` \| `never` |
+| `gpu_mode` | no | `always` \| `auto` \| `never` |
+| `attach` | repeatable | `slug_or_url|account_key` |
+
+Every validation error carries the offending line number and key, so users can
+fix typos without trial-and-error. Unknown keys are rejected rather than
+silently ignored, so a misspelled `runmode =` won't quietly disable itself.
+
+## Startup flow
+
+When `boincrs` starts, `bootstrap::attach_projects_from_env` reads the
+following environment variables in order:
+
+1. `BOINCRS_PROFILE_FILE` — path to a preset profile. All attach entries and
+   mode overrides in the profile are applied.
+2. `BOINCRS_PRIMEGRID_ACCOUNT_KEY` / `BOINCRS_ASTEROIDS_ACCOUNT_KEY` —
+   convenience shortcuts for the two projects shipped since the 0.1 beta.
+3. `BOINCRS_ATTACH_TEMPLATES` — semicolon-delimited `slug|key` pairs
+   (e.g. `primegrid|KEY1;rosetta|KEY2`).
+4. `BOINCRS_ATTACH_PROJECTS` — legacy semicolon-delimited `url|key` pairs.
+
+The resulting list is deduplicated by URL (first-write-wins), then each entry
+is attached via `project_attach` followed by `project_update`. Mode overrides
+from the profile are applied after attach completes.
+
+Parsing failures from env vars are **not fatal**: malformed entries are
+recorded in the returned `BootstrapReport.skipped` list and reported in the
+TUI status line, while the remainder of the bootstrap continues. Profile-load
+failures (e.g. unknown key, invalid mode value) **are** fatal — a bad profile
+is a clear config bug the user needs to correct.
+
+## Testing
+
+- `src/boinc/templates.rs` — unit tests for slug lookup, URL validation,
+  error messaging.
+- `src/boinc/profiles.rs` — unit tests for parser happy path, every error
+  variant, and round-trip serialization.
+- `tests/bootstrap_templates_tests.rs` — integration tests covering template
+  resolution, profile round-trip, comment/whitespace tolerance, and a mock
+  RPC attach call.

--- a/src/boinc/bootstrap.rs
+++ b/src/boinc/bootstrap.rs
@@ -1,72 +1,351 @@
-use crate::boinc::api::write::BoincWriteApi;
-use crate::boinc::rpc_client::BoincRpcClient;
-use crate::error::AppResult;
+//! Startup-time project attach and preset profile orchestration.
+//!
+//! The bootstrap layer reads user configuration from environment variables
+//! (and, optionally, a preset profile file) and applies it against a live
+//! BOINC RPC client. It is intentionally tolerant: malformed entries in a
+//! multi-attach list are skipped with a reason, so one bad line does not
+//! prevent the rest of the bootstrap from running.
+//!
+//! The same parsing helpers are exposed as `pub` so tests and future UI code
+//! can validate inputs without requiring a live BOINC daemon.
 
-#[derive(Debug, Clone)]
+use std::path::PathBuf;
+
+use crate::boinc::api::write::BoincWriteApi;
+use crate::boinc::profiles::{load_profile, PresetProfile, ProfileError};
+use crate::boinc::rpc_client::BoincRpcClient;
+use crate::boinc::templates::{self, TemplateError};
+use crate::error::{AppError, AppResult};
+
+/// One concrete attach request resolved against the templates registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachProject {
+    /// Canonical BOINC master URL to pass to `project_attach`.
     pub url: String,
+    /// Project authenticator / account key.
     pub account_key: String,
 }
 
-pub async fn attach_projects_from_env(rpc: &mut BoincRpcClient) -> AppResult<usize> {
-    let projects = discover_attach_projects();
-    if projects.is_empty() {
-        return Ok(0);
+/// Summary of what the bootstrap step actually did. Used by callers that want
+/// to surface a status line to the user (main loop, tests).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BootstrapReport {
+    /// URLs that were successfully sent through `project_attach` + `project_update`.
+    pub attached: Vec<String>,
+    /// Entries that were skipped, paired with a human-readable reason
+    /// (`(input, reason)`). Skips are non-fatal by design.
+    pub skipped: Vec<(String, String)>,
+    /// Name of the loaded preset profile, if any. `None` means no
+    /// `BOINCRS_PROFILE_FILE` was provided.
+    pub profile_name: Option<String>,
+    /// `true` if the CPU run-mode override from the profile was applied.
+    pub applied_run_mode: bool,
+    /// `true` if the network-mode override from the profile was applied.
+    pub applied_network_mode: bool,
+    /// `true` if the GPU-mode override from the profile was applied.
+    pub applied_gpu_mode: bool,
+}
+
+/// Applies any attach/profile configuration found in the environment.
+///
+/// Discovery order:
+/// 1. `BOINCRS_PROFILE_FILE` — path to a preset profile file. All attach and
+///    mode settings from the profile are applied.
+/// 2. `BOINCRS_PRIMEGRID_ACCOUNT_KEY`, `BOINCRS_ASTEROIDS_ACCOUNT_KEY`
+///    — original env vars, preserved for backwards compatibility.
+/// 3. `BOINCRS_ATTACH_TEMPLATES` — semicolon-separated `slug|key` pairs,
+///    e.g. `primegrid|abc;rosetta|def`.
+/// 4. `BOINCRS_ATTACH_PROJECTS` — semicolon-separated `url|key` pairs (legacy).
+pub async fn attach_projects_from_env(rpc: &mut BoincRpcClient) -> AppResult<BootstrapReport> {
+    let env = EnvInputs::from_env();
+    run_bootstrap(rpc, env).await
+}
+
+/// Applies a prepared set of [`EnvInputs`] against a live RPC client.
+///
+/// Extracted from [`attach_projects_from_env`] so tests can exercise the
+/// discovery → dedupe → attach pipeline without mutating process env vars.
+async fn run_bootstrap(rpc: &mut BoincRpcClient, inputs: EnvInputs) -> AppResult<BootstrapReport> {
+    let mut report = BootstrapReport::default();
+    let mut attach_list: Vec<AttachProject> = Vec::new();
+
+    let profile = match inputs.profile_path.as_ref() {
+        Some(path) => match load_profile(path) {
+            Ok(p) => {
+                report.profile_name = Some(p.name.clone());
+                Some(p)
+            }
+            Err(e) => {
+                return Err(AppError::Config(format!(
+                    "failed to load profile {}: {e}",
+                    path.display()
+                )))
+            }
+        },
+        None => None,
+    };
+
+    if let Some(ref p) = profile {
+        for entry in &p.attach {
+            attach_list.push(AttachProject {
+                url: entry.url.clone(),
+                account_key: entry.account_key.clone(),
+            });
+        }
     }
 
+    for (slug, key) in &inputs.well_known {
+        match templates::resolve_template(slug) {
+            Ok(url) => attach_list.push(AttachProject {
+                url,
+                account_key: key.clone(),
+            }),
+            Err(e) => report.skipped.push((slug.clone(), e.to_string())),
+        }
+    }
+
+    for raw in &inputs.template_pairs {
+        match parse_template_pair(raw) {
+            Ok(ap) => attach_list.push(ap),
+            Err(e) => report.skipped.push((raw.clone(), e)),
+        }
+    }
+
+    for raw in &inputs.legacy_url_pairs {
+        match parse_url_pair(raw) {
+            Ok(ap) => attach_list.push(ap),
+            Err(e) => report.skipped.push((raw.clone(), e)),
+        }
+    }
+
+    dedupe_by_url(&mut attach_list);
+
     let mut write_api = BoincWriteApi::new(rpc);
-    let mut attached = 0usize;
-    for project in projects {
+    for project in &attach_list {
         let _ = write_api
             .project_attach(project.url.as_str(), project.account_key.as_str())
             .await?;
         let _ = write_api.project_update(project.url.as_str()).await?;
-        attached += 1;
+        report.attached.push(project.url.clone());
     }
-    Ok(attached)
+
+    if let Some(p) = profile.as_ref() {
+        apply_profile_modes(&mut write_api, p, &mut report).await?;
+    }
+
+    Ok(report)
 }
 
-fn discover_attach_projects() -> Vec<AttachProject> {
-    let mut out = Vec::new();
+/// Applies any run-mode overrides declared by `profile`.
+///
+/// Each `Some(mode)` is forwarded to the corresponding BOINC `set_*_mode`
+/// RPC with a `duration_secs` of 0 (i.e. "permanent"). The supplied `report`
+/// is updated so callers can tell the user which modes were actually changed.
+async fn apply_profile_modes(
+    write_api: &mut BoincWriteApi<'_>,
+    profile: &PresetProfile,
+    report: &mut BootstrapReport,
+) -> AppResult<()> {
+    if let Some(mode) = profile.run_mode {
+        let _ = write_api.set_run_mode(mode, 0).await?;
+        report.applied_run_mode = true;
+    }
+    if let Some(mode) = profile.network_mode {
+        let _ = write_api.set_network_mode(mode, 0).await?;
+        report.applied_network_mode = true;
+    }
+    if let Some(mode) = profile.gpu_mode {
+        let _ = write_api.set_gpu_mode(mode, 0).await?;
+        report.applied_gpu_mode = true;
+    }
+    Ok(())
+}
 
-    if let Some(key) = read_env_trimmed("BOINCRS_PRIMEGRID_ACCOUNT_KEY") {
-        out.push(AttachProject {
-            url: "https://www.primegrid.com/".to_string(),
-            account_key: key,
-        });
-    }
-    if let Some(key) = read_env_trimmed("BOINCRS_ASTEROIDS_ACCOUNT_KEY") {
-        out.push(AttachProject {
-            url: "https://asteroidsathome.net/boinc/".to_string(),
-            account_key: key,
-        });
-    }
-    if let Some(spec) = read_env_trimmed("BOINCRS_ATTACH_PROJECTS") {
-        for pair in spec.split(';') {
-            if let Some(project) = parse_project_pair(pair) {
-                out.push(project);
-            }
+/// Collected configuration discovered from process environment variables.
+///
+/// This is the sole structured input to [`run_bootstrap`]; tests build
+/// `EnvInputs` directly rather than mutating global env state.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct EnvInputs {
+    /// Path to a preset profile to load, if any.
+    profile_path: Option<PathBuf>,
+    /// (slug, account_key) from dedicated env vars (`BOINCRS_<SLUG>_ACCOUNT_KEY`).
+    well_known: Vec<(String, String)>,
+    /// Raw `slug|key[;…]` values from `BOINCRS_ATTACH_TEMPLATES`.
+    template_pairs: Vec<String>,
+    /// Raw `url|key[;…]` values from `BOINCRS_ATTACH_PROJECTS` (legacy).
+    legacy_url_pairs: Vec<String>,
+}
+
+impl EnvInputs {
+    /// Populates `EnvInputs` by reading the documented `BOINCRS_*` env vars.
+    ///
+    /// Missing or empty variables are simply left unset; nothing about the
+    /// return value is fatal on its own — downstream logic decides whether
+    /// an empty configuration is acceptable.
+    fn from_env() -> Self {
+        let mut out = Self::default();
+        if let Some(path) = read_env_trimmed("BOINCRS_PROFILE_FILE") {
+            out.profile_path = Some(PathBuf::from(path));
         }
+        if let Some(key) = read_env_trimmed("BOINCRS_PRIMEGRID_ACCOUNT_KEY") {
+            out.well_known.push(("primegrid".to_string(), key));
+        }
+        if let Some(key) = read_env_trimmed("BOINCRS_ASTEROIDS_ACCOUNT_KEY") {
+            out.well_known.push(("asteroids".to_string(), key));
+        }
+        if let Some(spec) = read_env_trimmed("BOINCRS_ATTACH_TEMPLATES") {
+            out.template_pairs = split_pairs(&spec);
+        }
+        if let Some(spec) = read_env_trimmed("BOINCRS_ATTACH_PROJECTS") {
+            out.legacy_url_pairs = split_pairs(&spec);
+        }
+        out
     }
-    out
 }
 
-fn parse_project_pair(pair: &str) -> Option<AttachProject> {
-    let mut parts = pair.split('|');
-    let url = parts.next()?.trim();
-    let key = parts.next()?.trim();
-    if url.is_empty() || key.is_empty() {
-        return None;
+/// Splits a `a|1;b|2; ;c|3` style specification into trimmed, non-empty entries.
+///
+/// Whitespace around entries is stripped, and empty segments (produced by
+/// trailing or doubled `;`) are dropped, so tolerant hand-edited env values
+/// still parse cleanly.
+fn split_pairs(spec: &str) -> Vec<String> {
+    spec.split(';')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Parses `slug_or_url|account_key` against the template registry.
+pub fn parse_template_pair(pair: &str) -> Result<AttachProject, String> {
+    let (left, right) = pair
+        .split_once('|')
+        .ok_or_else(|| "expected 'slug|account_key'".to_string())?;
+    let slug = left.trim();
+    let key = right.trim();
+    if slug.is_empty() || key.is_empty() {
+        return Err("slug and account_key must be non-empty".to_string());
     }
-    Some(AttachProject {
+    let url = templates::resolve_template(slug).map_err(|e| match e {
+        TemplateError::UnknownSlug(_, known) => {
+            format!("unknown template {slug:?}. Known: {known}")
+        }
+        other => other.to_string(),
+    })?;
+    Ok(AttachProject {
+        url,
+        account_key: key.to_string(),
+    })
+}
+
+/// Parses `url|account_key` without template resolution (legacy).
+pub fn parse_url_pair(pair: &str) -> Result<AttachProject, String> {
+    let (left, right) = pair
+        .split_once('|')
+        .ok_or_else(|| "expected 'url|account_key'".to_string())?;
+    let url = left.trim();
+    let key = right.trim();
+    templates::validate_project_url(url).map_err(|e| e.to_string())?;
+    if key.is_empty() {
+        return Err("account_key must be non-empty".to_string());
+    }
+    Ok(AttachProject {
         url: url.to_string(),
         account_key: key.to_string(),
     })
 }
 
+/// Removes duplicate attach entries, keeping the first occurrence of each URL.
+///
+/// Profile attachments take precedence over env-var shortcuts simply because
+/// they are pushed into the list first. The stable ordering makes the
+/// resulting behavior predictable for users.
+fn dedupe_by_url(list: &mut Vec<AttachProject>) {
+    let mut seen: Vec<String> = Vec::new();
+    list.retain(|p| {
+        if seen.iter().any(|u| u == &p.url) {
+            false
+        } else {
+            seen.push(p.url.clone());
+            true
+        }
+    });
+}
+
+/// Reads an environment variable and returns `Some(trimmed_value)` only when
+/// the variable is set and not empty after trimming whitespace.
 fn read_env_trimmed(key: &str) -> Option<String> {
     std::env::var(key)
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
+}
+
+/// Surfaces a profile-load error as an `AppError::Config`.
+impl From<ProfileError> for AppError {
+    fn from(value: ProfileError) -> Self {
+        AppError::Config(value.to_string())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_template_pair_resolves_slug() {
+        let ap = parse_template_pair("primegrid|ABC").expect("valid");
+        assert_eq!(ap.url, "https://www.primegrid.com/");
+        assert_eq!(ap.account_key, "ABC");
+    }
+
+    #[test]
+    fn parse_template_pair_rejects_unknown_slug_with_hint() {
+        let err = parse_template_pair("not-a-project|KEY").expect_err("unknown");
+        assert!(err.contains("Known:"));
+    }
+
+    #[test]
+    fn parse_template_pair_rejects_missing_parts() {
+        assert!(parse_template_pair("primegrid").is_err());
+        assert!(parse_template_pair("|KEY").is_err());
+        assert!(parse_template_pair("primegrid|").is_err());
+    }
+
+    #[test]
+    fn parse_url_pair_validates_url() {
+        let ap = parse_url_pair("https://example.org/boinc/|KEY").expect("valid");
+        assert_eq!(ap.url, "https://example.org/boinc/");
+        assert!(parse_url_pair("not-a-url|KEY").is_err());
+        assert!(parse_url_pair("https://example.org/|").is_err());
+    }
+
+    #[test]
+    fn split_pairs_trims_and_ignores_empty() {
+        let v = split_pairs("a|1 ; ; b|2 ;");
+        assert_eq!(v, vec!["a|1".to_string(), "b|2".to_string()]);
+    }
+
+    #[test]
+    fn dedupe_by_url_keeps_first_occurrence() {
+        let mut list = vec![
+            AttachProject {
+                url: "u1".to_string(),
+                account_key: "k1".to_string(),
+            },
+            AttachProject {
+                url: "u1".to_string(),
+                account_key: "k2".to_string(),
+            },
+            AttachProject {
+                url: "u2".to_string(),
+                account_key: "k3".to_string(),
+            },
+        ];
+        dedupe_by_url(&mut list);
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].account_key, "k1");
+        assert_eq!(list[1].url, "u2");
+    }
 }

--- a/src/boinc/mod.rs
+++ b/src/boinc/mod.rs
@@ -6,6 +6,8 @@
 pub mod api;
 pub mod bootstrap;
 pub mod models;
+pub mod profiles;
 pub mod protocol;
 pub mod rpc_client;
+pub mod templates;
 pub mod transport;

--- a/src/boinc/profiles.rs
+++ b/src/boinc/profiles.rs
@@ -1,0 +1,425 @@
+//! Preset runtime profiles for common BOINC onboarding flows.
+//!
+//! A preset profile bundles the kinds of things a user typically reconfigures
+//! right after installing `boincrs`:
+//!
+//! * which BOINC projects to attach (by template slug or explicit URL),
+//! * the desired CPU/network/GPU run-modes.
+//!
+//! Profiles are persisted as a tiny, human-readable `key = value` text format
+//! so we don't take a new TOML/JSON dependency. Any line beginning with `#`
+//! is a comment. Unknown keys are rejected by [`parse_profile`] to keep typos
+//! from silently disabling a preference.
+//!
+//! The parser is defensive: every invalid input yields a [`ProfileError`]
+//! with a human-readable reason. That error is surfaced to the UI so the user
+//! sees *why* a profile was rejected instead of a generic failure.
+
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::boinc::models::RunMode;
+use crate::boinc::templates::{self, TemplateError};
+
+/// A single attach request within a profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachEntry {
+    /// Canonical master URL (already resolved from a slug if applicable).
+    pub url: String,
+    /// Project authenticator / account key.
+    pub account_key: String,
+}
+
+/// A persistent preset the user can re-apply at startup.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PresetProfile {
+    /// User-chosen label, e.g. `desktop-workstation`.
+    pub name: String,
+    /// Optional CPU run-mode override applied after attach.
+    pub run_mode: Option<RunMode>,
+    /// Optional network activity mode override.
+    pub network_mode: Option<RunMode>,
+    /// Optional GPU run-mode override.
+    pub gpu_mode: Option<RunMode>,
+    /// Ordered list of projects to attach.
+    pub attach: Vec<AttachEntry>,
+}
+
+/// Errors reported when loading or validating a profile.
+#[derive(Debug, Error)]
+pub enum ProfileError {
+    /// Profile name was missing or empty after trimming.
+    #[error("profile name must not be empty")]
+    MissingName,
+    /// Profile name contained characters that would break path / display use.
+    #[error("invalid profile name {0:?}: only ASCII letters, digits, '-', '_' allowed")]
+    InvalidName(
+        /// The rejected name, echoed back verbatim so the user can see the typo.
+        String,
+    ),
+    /// A line could not be parsed as `key = value` (after trimming/comments).
+    #[error("line {line}: expected 'key = value', got {raw:?}")]
+    MalformedLine {
+        /// 1-based line number of the offending input.
+        line: usize,
+        /// Raw line text, preserved verbatim for error messages.
+        raw: String,
+    },
+    /// Key was recognized but value was invalid for that key.
+    #[error("line {line}: invalid value for {key}: {reason}")]
+    InvalidValue {
+        /// 1-based line number of the offending input.
+        line: usize,
+        /// Configuration key whose value could not be accepted.
+        key: String,
+        /// Human-readable explanation of why the value was rejected.
+        reason: String,
+    },
+    /// Attach entry was missing either the project reference or account key.
+    #[error("line {line}: attach entry must be 'slug_or_url|account_key'")]
+    MalformedAttach {
+        /// 1-based line number of the malformed `attach = ...` entry.
+        line: usize,
+    },
+    /// Attach entry referenced a template slug / URL that could not be resolved.
+    #[error("line {line}: {source}")]
+    UnknownTemplate {
+        /// 1-based line number of the offending `attach = ...` entry.
+        line: usize,
+        /// Underlying template-resolution error (kept in the chain via `#[source]`).
+        #[source]
+        source: TemplateError,
+    },
+    /// An unknown configuration key was supplied.
+    #[error("line {line}: unknown profile key {key:?}")]
+    UnknownKey {
+        /// 1-based line number where the unknown key appeared.
+        line: usize,
+        /// The unrecognized key, lower-cased.
+        key: String,
+    },
+    /// The profile parsed, but had neither attach entries nor mode overrides.
+    #[error("profile {0:?} is empty: no attach entries or mode overrides")]
+    EmptyProfile(
+        /// The parsed profile name, echoed back for context.
+        String,
+    ),
+    /// I/O failure while reading or writing a profile file.
+    #[error("profile I/O error at {path:?}: {source}")]
+    Io {
+        /// Filesystem path the I/O was attempted against.
+        path: String,
+        /// Underlying `std::io::Error` preserved in the error chain.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl PresetProfile {
+    /// Builds an empty profile with just a validated name.
+    pub fn new(name: impl Into<String>) -> Result<Self, ProfileError> {
+        let name = name.into();
+        validate_profile_name(&name)?;
+        Ok(Self {
+            name,
+            ..Self::default()
+        })
+    }
+
+    /// Serializes the profile back to the `key = value` text format.
+    pub fn to_text(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("# boincrs profile: {}\n", self.name));
+        out.push_str(&format!("name = {}\n", self.name));
+        if let Some(mode) = self.run_mode {
+            out.push_str(&format!("run_mode = {}\n", mode.as_boinc_tag()));
+        }
+        if let Some(mode) = self.network_mode {
+            out.push_str(&format!("network_mode = {}\n", mode.as_boinc_tag()));
+        }
+        if let Some(mode) = self.gpu_mode {
+            out.push_str(&format!("gpu_mode = {}\n", mode.as_boinc_tag()));
+        }
+        for entry in &self.attach {
+            out.push_str(&format!("attach = {}|{}\n", entry.url, entry.account_key));
+        }
+        out
+    }
+}
+
+/// Parses a preset profile from text.
+///
+/// Recognized keys:
+/// * `name` — profile name (required, letters/digits/`-`/`_`).
+/// * `run_mode`, `network_mode`, `gpu_mode` — one of `always`, `auto`, `never`.
+/// * `attach` — repeated, formatted as `slug_or_url|account_key`.
+///
+/// # Examples
+///
+/// ```
+/// use boincrs::boinc::profiles::parse_profile;
+///
+/// let p = parse_profile("
+///     name = desktop
+///     run_mode = always
+///     attach = primegrid|abc123
+/// ").expect("valid profile");
+/// assert_eq!(p.name, "desktop");
+/// assert_eq!(p.attach.len(), 1);
+/// assert_eq!(p.attach[0].url, "https://www.primegrid.com/");
+/// ```
+pub fn parse_profile(text: &str) -> Result<PresetProfile, ProfileError> {
+    let mut profile = PresetProfile::default();
+
+    for (idx, raw_line) in text.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = strip_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            return Err(ProfileError::MalformedLine {
+                line: line_no,
+                raw: raw_line.to_string(),
+            });
+        };
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+
+        match key.as_str() {
+            "name" => {
+                validate_profile_name(value)?;
+                profile.name = value.to_string();
+            }
+            "run_mode" => profile.run_mode = Some(parse_run_mode(value, line_no, &key)?),
+            "network_mode" => profile.network_mode = Some(parse_run_mode(value, line_no, &key)?),
+            "gpu_mode" => profile.gpu_mode = Some(parse_run_mode(value, line_no, &key)?),
+            "attach" => profile.attach.push(parse_attach(value, line_no)?),
+            other => {
+                return Err(ProfileError::UnknownKey {
+                    line: line_no,
+                    key: other.to_string(),
+                });
+            }
+        }
+    }
+
+    if profile.name.is_empty() {
+        return Err(ProfileError::MissingName);
+    }
+    if profile.attach.is_empty()
+        && profile.run_mode.is_none()
+        && profile.network_mode.is_none()
+        && profile.gpu_mode.is_none()
+    {
+        return Err(ProfileError::EmptyProfile(profile.name));
+    }
+
+    Ok(profile)
+}
+
+/// Reads and parses a profile from `path`.
+pub fn load_profile(path: impl AsRef<Path>) -> Result<PresetProfile, ProfileError> {
+    let path_ref = path.as_ref();
+    let text = std::fs::read_to_string(path_ref).map_err(|e| ProfileError::Io {
+        path: path_ref.display().to_string(),
+        source: e,
+    })?;
+    parse_profile(&text)
+}
+
+/// Serializes a profile and writes it to `path`.
+pub fn save_profile(path: impl AsRef<Path>, profile: &PresetProfile) -> Result<(), ProfileError> {
+    validate_profile_name(&profile.name)?;
+    let path_ref = path.as_ref();
+    std::fs::write(path_ref, profile.to_text()).map_err(|e| ProfileError::Io {
+        path: path_ref.display().to_string(),
+        source: e,
+    })
+}
+
+/// Validates a profile name against the accepted character set.
+///
+/// Names must be non-empty after trimming and may only contain ASCII
+/// letters, digits, `-`, and `_` so they are safe to use as file names
+/// and to display in status lines.
+fn validate_profile_name(name: &str) -> Result<(), ProfileError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(ProfileError::MissingName);
+    }
+    let ok = trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if !ok {
+        return Err(ProfileError::InvalidName(trimmed.to_string()));
+    }
+    Ok(())
+}
+
+/// Parses a run-mode string (`always` / `auto` / `never`) case-insensitively.
+///
+/// The `line` and `key` parameters are only used to build a
+/// [`ProfileError::InvalidValue`] pointing at the offending input, so
+/// callers get actionable feedback rather than a generic "bad value" message.
+fn parse_run_mode(value: &str, line: usize, key: &str) -> Result<RunMode, ProfileError> {
+    match value.to_ascii_lowercase().as_str() {
+        "always" => Ok(RunMode::Always),
+        "auto" => Ok(RunMode::Auto),
+        "never" => Ok(RunMode::Never),
+        other => Err(ProfileError::InvalidValue {
+            line,
+            key: key.to_string(),
+            reason: format!("expected always|auto|never, got {other:?}"),
+        }),
+    }
+}
+
+/// Parses an `attach = slug_or_url|account_key` value into an [`AttachEntry`].
+///
+/// Both sides of the `|` separator must be non-empty after trimming. The
+/// left side is routed through [`templates::resolve_template`] so callers can
+/// mix well-known slugs and raw URLs freely. On failure the returned error
+/// carries the 1-based `line` number for user-facing messages.
+fn parse_attach(value: &str, line: usize) -> Result<AttachEntry, ProfileError> {
+    let (left, right) = value
+        .split_once('|')
+        .ok_or(ProfileError::MalformedAttach { line })?;
+    let slug_or_url = left.trim();
+    let key = right.trim();
+    if slug_or_url.is_empty() || key.is_empty() {
+        return Err(ProfileError::MalformedAttach { line });
+    }
+    let url = templates::resolve_template(slug_or_url)
+        .map_err(|e| ProfileError::UnknownTemplate { line, source: e })?;
+    Ok(AttachEntry {
+        url,
+        account_key: key.to_string(),
+    })
+}
+
+/// Returns `line` with any trailing `# comment` removed.
+///
+/// The first `#` wins, so `attach = foo|bar # note` yields `attach = foo|bar `.
+/// Lines without a `#` are returned unchanged.
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(i) => &line[..i],
+        None => line,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_attach_profile() {
+        let text = "
+            # a profile
+            name = home-desktop
+            attach = primegrid|KEY_A
+            attach = https://asteroidsathome.net/boinc/|KEY_B
+        ";
+        let p = parse_profile(text).expect("should parse");
+        assert_eq!(p.name, "home-desktop");
+        assert_eq!(p.attach.len(), 2);
+        assert_eq!(p.attach[0].url, "https://www.primegrid.com/");
+        assert_eq!(p.attach[0].account_key, "KEY_A");
+        assert_eq!(p.attach[1].url, "https://asteroidsathome.net/boinc/");
+    }
+
+    #[test]
+    fn parse_modes() {
+        let text = "
+            name = laptop
+            run_mode = auto
+            network_mode = never
+            gpu_mode = always
+        ";
+        let p = parse_profile(text).expect("should parse");
+        assert_eq!(p.run_mode, Some(RunMode::Auto));
+        assert_eq!(p.network_mode, Some(RunMode::Never));
+        assert_eq!(p.gpu_mode, Some(RunMode::Always));
+    }
+
+    #[test]
+    fn rejects_missing_name() {
+        let err = parse_profile("run_mode = auto").expect_err("no name");
+        assert!(matches!(err, ProfileError::MissingName));
+    }
+
+    #[test]
+    fn rejects_empty_profile() {
+        let err = parse_profile("name = foo").expect_err("empty");
+        match err {
+            ProfileError::EmptyProfile(name) => assert_eq!(name, "foo"),
+            other => panic!("expected EmptyProfile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_run_mode_with_line_info() {
+        let err = parse_profile("name=foo\nrun_mode = sometimes").expect_err("bad mode");
+        match err {
+            ProfileError::InvalidValue { line, key, .. } => {
+                assert_eq!(line, 2);
+                assert_eq!(key, "run_mode");
+            }
+            other => panic!("expected InvalidValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_key() {
+        let err = parse_profile("name=foo\nbogus = 1").expect_err("unknown");
+        match err {
+            ProfileError::UnknownKey { line, key } => {
+                assert_eq!(line, 2);
+                assert_eq!(key, "bogus");
+            }
+            other => panic!("expected UnknownKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_attach() {
+        let err = parse_profile("name=foo\nattach = primegrid").expect_err("missing key");
+        match err {
+            ProfileError::MalformedAttach { line } => assert_eq!(line, 2),
+            other => panic!("expected MalformedAttach, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_template_in_attach() {
+        let err = parse_profile("name=foo\nattach = not-real|KEY").expect_err("unknown template");
+        match err {
+            ProfileError::UnknownTemplate { line, .. } => assert_eq!(line, 2),
+            other => panic!("expected UnknownTemplate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_name() {
+        let err = PresetProfile::new("bad name!").expect_err("invalid");
+        assert!(matches!(err, ProfileError::InvalidName(_)));
+    }
+
+    #[test]
+    fn round_trips_through_text() {
+        let mut p = PresetProfile::new("round-trip").expect("valid");
+        p.run_mode = Some(RunMode::Always);
+        p.gpu_mode = Some(RunMode::Never);
+        p.attach.push(AttachEntry {
+            url: "https://www.primegrid.com/".to_string(),
+            account_key: "KEY".to_string(),
+        });
+        let text = p.to_text();
+        let parsed = parse_profile(&text).expect("round-trip parse");
+        assert_eq!(parsed, p);
+    }
+}

--- a/src/boinc/templates.rs
+++ b/src/boinc/templates.rs
@@ -1,0 +1,320 @@
+//! Curated project attach templates.
+//!
+//! The TUI needs to support attaching BOINC projects beyond the initial
+//! PrimeGrid / Asteroids@home pair. To keep onboarding fast and consistent, we
+//! ship a small registry of **well-known projects** with their canonical master
+//! URLs and human-readable metadata. Callers supply a **slug** (e.g.
+//! `primegrid`) together with an account key, and the bootstrap layer uses
+//! [`resolve_template`] to recover the canonical URL.
+//!
+//! This module is intentionally self-contained — no I/O, no async — so it can
+//! be validated with fast unit tests and reused from both the bootstrap path
+//! and eventually the interactive attach UI.
+
+use thiserror::Error;
+
+/// A documented BOINC project that users can attach by slug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectTemplate {
+    /// Short kebab-case identifier used in config (`primegrid`).
+    pub slug: &'static str,
+    /// Display name shown to the user (`PrimeGrid`).
+    pub name: &'static str,
+    /// Canonical BOINC master URL used in `project_attach`.
+    pub url: &'static str,
+    /// One-line description, shown in docs / future pickers.
+    pub summary: &'static str,
+    /// Category tags (`math`, `biology`, …) used for future filtering.
+    pub categories: &'static [&'static str],
+}
+
+/// Errors produced when resolving or validating a template input.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TemplateError {
+    /// The provided slug / URL does not match any well-known template.
+    #[error("unknown project template: {0:?}. Known slugs: {1}")]
+    UnknownSlug(
+        /// User-supplied slug or URL that failed to resolve.
+        String,
+        /// Comma-separated list of known slugs, included in the message as a hint.
+        String,
+    ),
+    /// The input string was empty after trimming.
+    #[error("project template reference was empty")]
+    EmptyInput,
+    /// A free-form URL was supplied but it is not a valid BOINC master URL.
+    #[error("invalid project URL {0:?}: {1}")]
+    InvalidUrl(
+        /// Offending URL, echoed back for debugging.
+        String,
+        /// Short reason describing which rule the URL violated.
+        &'static str,
+    ),
+}
+
+/// Returns the curated registry of well-known BOINC projects.
+///
+/// Entries are kept alphabetical so the list is easy to scan in docs and CLI
+/// help output.
+pub fn all_templates() -> &'static [ProjectTemplate] {
+    REGISTRY
+}
+
+/// Looks up a template by exact slug match (case-insensitive).
+pub fn find_template(slug: &str) -> Option<&'static ProjectTemplate> {
+    let needle = slug.trim().to_ascii_lowercase();
+    REGISTRY.iter().find(|t| t.slug == needle)
+}
+
+/// Resolves a user-supplied project reference to a canonical master URL.
+///
+/// Accepts either:
+/// * a **slug** from [`all_templates`] (e.g. `primegrid`), or
+/// * a fully qualified **master URL** (e.g. `https://www.primegrid.com/`),
+///   which is validated with [`validate_project_url`].
+///
+/// # Examples
+///
+/// ```
+/// use boincrs::boinc::templates::resolve_template;
+///
+/// assert_eq!(
+///     resolve_template("primegrid").expect("known slug"),
+///     "https://www.primegrid.com/"
+/// );
+/// assert_eq!(
+///     resolve_template("https://boinc.example.org/").expect("valid url"),
+///     "https://boinc.example.org/"
+/// );
+/// ```
+pub fn resolve_template(input: &str) -> Result<String, TemplateError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(TemplateError::EmptyInput);
+    }
+
+    if looks_like_url(trimmed) {
+        validate_project_url(trimmed)?;
+        return Ok(trimmed.to_string());
+    }
+
+    if let Some(t) = find_template(trimmed) {
+        return Ok(t.url.to_string());
+    }
+
+    let known: Vec<&'static str> = REGISTRY.iter().map(|t| t.slug).collect();
+    Err(TemplateError::UnknownSlug(
+        trimmed.to_string(),
+        known.join(", "),
+    ))
+}
+
+/// Validates that `url` looks like a reasonable BOINC project master URL.
+///
+/// We deliberately do not perform DNS resolution here — the actual attach call
+/// will surface protocol errors. The aim is to catch obvious typos early so
+/// the RPC never sees them.
+pub fn validate_project_url(url: &str) -> Result<(), TemplateError> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err(TemplateError::EmptyInput);
+    }
+    if !looks_like_url(trimmed) {
+        return Err(TemplateError::InvalidUrl(
+            trimmed.to_string(),
+            "must start with http:// or https://",
+        ));
+    }
+    if trimmed.contains(' ') || trimmed.contains('\t') {
+        return Err(TemplateError::InvalidUrl(
+            trimmed.to_string(),
+            "must not contain whitespace",
+        ));
+    }
+    let after_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
+    let host = after_scheme.split('/').next().unwrap_or("");
+    if host.is_empty() || !host.contains('.') {
+        return Err(TemplateError::InvalidUrl(
+            trimmed.to_string(),
+            "host must contain a dot (e.g. example.org)",
+        ));
+    }
+    Ok(())
+}
+
+/// Returns `true` when `s` starts with `http://` or `https://`.
+///
+/// A deliberately cheap check — we do not parse the URL here. Full validation
+/// is performed by [`validate_project_url`] when the string is actually used
+/// as a master URL.
+fn looks_like_url(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://")
+}
+
+/// Registry of curated templates. Keep alphabetical by slug.
+const REGISTRY: &[ProjectTemplate] = &[
+    ProjectTemplate {
+        slug: "asteroids",
+        name: "Asteroids@home",
+        url: "https://asteroidsathome.net/boinc/",
+        summary: "Determines shapes and spin states of asteroids.",
+        categories: &["astronomy", "physics"],
+    },
+    ProjectTemplate {
+        slug: "einstein",
+        name: "Einstein@Home",
+        url: "https://einsteinathome.org/",
+        summary: "Searches for neutron stars using gravitational-wave and radio data.",
+        categories: &["astronomy", "physics"],
+    },
+    ProjectTemplate {
+        slug: "gpugrid",
+        name: "GPUGRID",
+        url: "https://www.gpugrid.net/",
+        summary: "Molecular dynamics simulations accelerated on GPUs.",
+        categories: &["biology", "gpu"],
+    },
+    ProjectTemplate {
+        slug: "lhc",
+        name: "LHC@home",
+        url: "https://lhcathome.cern.ch/lhcathome/",
+        summary: "Simulations in support of CERN's Large Hadron Collider.",
+        categories: &["physics"],
+    },
+    ProjectTemplate {
+        slug: "milkyway",
+        name: "Milkyway@Home",
+        url: "https://milkyway.cs.rpi.edu/milkyway/",
+        summary: "Models the 3D structure of the Milky Way galaxy.",
+        categories: &["astronomy"],
+    },
+    ProjectTemplate {
+        slug: "primegrid",
+        name: "PrimeGrid",
+        url: "https://www.primegrid.com/",
+        summary: "Searches for large prime numbers of mathematical interest.",
+        categories: &["math", "prime-numbers"],
+    },
+    ProjectTemplate {
+        slug: "rosetta",
+        name: "Rosetta@home",
+        url: "https://boinc.bakerlab.org/rosetta/",
+        summary: "Protein structure prediction for disease research.",
+        categories: &["biology", "medicine"],
+    },
+    ProjectTemplate {
+        slug: "seti",
+        name: "SETI-like (Cosmology@Home)",
+        url: "https://www.cosmologyathome.org/",
+        summary: "Cosmological model parameter estimation.",
+        categories: &["astronomy", "cosmology"],
+    },
+    ProjectTemplate {
+        slug: "worldcommunitygrid",
+        name: "World Community Grid",
+        url: "https://www.worldcommunitygrid.org/",
+        summary: "Humanitarian research spanning climate, health, and disease.",
+        categories: &["biology", "climate", "medicine"],
+    },
+    ProjectTemplate {
+        slug: "yoyo",
+        name: "yoyo@home",
+        url: "https://www.rechenkraft.net/yoyo/",
+        summary: "Umbrella project hosting several scientific subprojects.",
+        categories: &["umbrella"],
+    },
+];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_slugs_are_unique_and_kebab_case() {
+        let mut seen: Vec<&str> = Vec::new();
+        for t in all_templates() {
+            assert!(
+                !seen.contains(&t.slug),
+                "duplicate slug in registry: {}",
+                t.slug
+            );
+            seen.push(t.slug);
+            assert!(
+                t.slug.chars().all(|c| c.is_ascii_lowercase() || c == '-'),
+                "slug must be kebab-case ascii: {}",
+                t.slug
+            );
+            assert!(
+                t.url.starts_with("https://") || t.url.starts_with("http://"),
+                "template {} has non-http URL {}",
+                t.slug,
+                t.url
+            );
+        }
+        assert!(seen.len() >= 8, "need a meaningful set of templates");
+    }
+
+    #[test]
+    fn find_template_is_case_insensitive_and_trims() {
+        assert!(find_template("primegrid").is_some());
+        assert!(find_template("  PRIMEGRID  ").is_some());
+        assert!(find_template("unknownproject").is_none());
+    }
+
+    #[test]
+    fn resolve_template_returns_url_for_known_slug() {
+        let url = resolve_template("asteroids").expect("known slug");
+        assert_eq!(url, "https://asteroidsathome.net/boinc/");
+    }
+
+    #[test]
+    fn resolve_template_accepts_valid_url_passthrough() {
+        let url = resolve_template("https://boinc.example.org/project/").expect("valid url");
+        assert_eq!(url, "https://boinc.example.org/project/");
+    }
+
+    #[test]
+    fn resolve_template_rejects_empty_input() {
+        assert!(matches!(
+            resolve_template("   "),
+            Err(TemplateError::EmptyInput)
+        ));
+    }
+
+    #[test]
+    fn resolve_template_reports_unknown_slug_with_hint() {
+        let err = resolve_template("not-a-real-project").expect_err("unknown");
+        match err {
+            TemplateError::UnknownSlug(input, known) => {
+                assert_eq!(input, "not-a-real-project");
+                assert!(known.contains("primegrid"));
+            }
+            other => panic!("expected UnknownSlug, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_project_url_requires_scheme_and_host() {
+        assert!(validate_project_url("https://boinc.example.org/").is_ok());
+        assert!(matches!(
+            validate_project_url("boinc.example.org"),
+            Err(TemplateError::InvalidUrl(_, _))
+        ));
+        assert!(matches!(
+            validate_project_url("https://nodothost/"),
+            Err(TemplateError::InvalidUrl(_, _))
+        ));
+        assert!(matches!(
+            validate_project_url("https://has space.org/"),
+            Err(TemplateError::InvalidUrl(_, _))
+        ));
+        assert!(matches!(
+            validate_project_url(""),
+            Err(TemplateError::EmptyInput)
+        ));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum AppError {
     /// UI/runtime interaction error.
     #[error("UI error: {0}")]
     Ui(String),
+    /// Configuration input was invalid (template slug, profile, env var).
+    #[error("configuration error: {0}")]
+    Config(String),
 }
 
 impl AppError {
@@ -33,6 +36,7 @@ impl AppError {
             AppError::InvalidResponse(_) => true,
             AppError::AuthenticationFailed => false,
             AppError::Ui(_) => false,
+            AppError::Config(_) => false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,26 @@ async fn main() -> AppResult<()> {
 
     let transport = TcpBoincTransport::connect(endpoint.clone()).await?;
     let mut rpc_client = BoincRpcClient::new(Box::new(transport), password.clone());
-    let _ = attach_projects_from_env(&mut rpc_client).await?;
+    let bootstrap_report = attach_projects_from_env(&mut rpc_client).await?;
     let mut controller = AppController::new(rpc_client, endpoint, password);
+    if !bootstrap_report.attached.is_empty() || bootstrap_report.profile_name.is_some() {
+        let profile_part = bootstrap_report
+            .profile_name
+            .as_deref()
+            .map(|n| format!(" profile:{n}"))
+            .unwrap_or_default();
+        let skipped_part = if bootstrap_report.skipped.is_empty() {
+            String::new()
+        } else {
+            format!(" skipped:{}", bootstrap_report.skipped.len())
+        };
+        controller.state.status_line = format!(
+            "Bootstrap: attached {}{}{}",
+            bootstrap_report.attached.len(),
+            profile_part,
+            skipped_part,
+        );
+    }
     controller.run().await
 }
 

--- a/tests/bootstrap_templates_tests.rs
+++ b/tests/bootstrap_templates_tests.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use boincrs::boinc::bootstrap::{parse_template_pair, parse_url_pair, AttachProject};
+use boincrs::boinc::profiles::{parse_profile, AttachEntry, PresetProfile};
+use boincrs::boinc::rpc_client::BoincRpcClient;
+use boincrs::boinc::templates::{all_templates, find_template, resolve_template};
+use boincrs::boinc::transport::BoincTransport;
+use boincrs::error::AppResult;
+
+struct CountingTransport {
+    writes: Vec<Vec<u8>>,
+}
+
+impl CountingTransport {
+    fn new() -> Self {
+        Self { writes: Vec::new() }
+    }
+}
+
+#[async_trait]
+impl BoincTransport for CountingTransport {
+    async fn send(&mut self, payload: &[u8]) -> AppResult<()> {
+        self.writes.push(payload.to_vec());
+        Ok(())
+    }
+
+    async fn receive(&mut self) -> AppResult<Vec<u8>> {
+        Ok(b"<boinc_gui_rpc_reply><success/></boinc_gui_rpc_reply>\x03".to_vec())
+    }
+}
+
+#[test]
+fn registry_contains_primegrid_and_asteroids_at_minimum() {
+    let slugs: Vec<&str> = all_templates().iter().map(|t| t.slug).collect();
+    assert!(slugs.contains(&"primegrid"), "slugs: {slugs:?}");
+    assert!(slugs.contains(&"asteroids"), "slugs: {slugs:?}");
+}
+
+#[test]
+fn template_lookup_trims_and_normalizes_case() {
+    let pg = find_template("  PrimeGrid ").expect("should find primegrid");
+    assert_eq!(pg.url, "https://www.primegrid.com/");
+}
+
+#[test]
+fn resolve_template_provides_clear_error_for_typo() {
+    let err = resolve_template("primgrid").expect_err("typo should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown project template"), "msg: {msg}");
+    assert!(
+        msg.contains("primegrid"),
+        "msg should hint known slugs: {msg}"
+    );
+}
+
+#[test]
+fn template_pair_round_trip_matches_profile_attach_entry() {
+    let ap: AttachProject = parse_template_pair("rosetta|SECRET").expect("valid");
+    assert_eq!(ap.url, "https://boinc.bakerlab.org/rosetta/");
+    assert_eq!(ap.account_key, "SECRET");
+}
+
+#[test]
+fn legacy_url_pair_rejects_obvious_typos() {
+    assert!(parse_url_pair("htp://example.org/|KEY").is_err());
+    assert!(parse_url_pair("https://example.org/|KEY").is_ok());
+}
+
+#[test]
+fn profile_round_trip_persists_and_restores_preferences() {
+    let mut profile = PresetProfile::new("test-profile").expect("valid name");
+    profile.run_mode = Some(boincrs::boinc::models::RunMode::Always);
+    profile.network_mode = Some(boincrs::boinc::models::RunMode::Auto);
+    profile.gpu_mode = Some(boincrs::boinc::models::RunMode::Never);
+    profile.attach.push(AttachEntry {
+        url: "https://www.primegrid.com/".to_string(),
+        account_key: "KEY1".to_string(),
+    });
+    profile.attach.push(AttachEntry {
+        url: "https://asteroidsathome.net/boinc/".to_string(),
+        account_key: "KEY2".to_string(),
+    });
+
+    let serialized = profile.to_text();
+    assert!(serialized.contains("name = test-profile"));
+    assert!(serialized.contains("run_mode = always"));
+    assert!(serialized.contains("attach = https://www.primegrid.com/|KEY1"));
+
+    let parsed = parse_profile(&serialized).expect("round-trip parse");
+    assert_eq!(parsed, profile);
+}
+
+#[test]
+fn profile_rejects_invalid_modes_with_line_and_key_info() {
+    let err = parse_profile("name = foo\nrun_mode = sometimes").expect_err("invalid mode");
+    let msg = err.to_string();
+    assert!(msg.contains("line 2"), "msg: {msg}");
+    assert!(msg.contains("run_mode"), "msg: {msg}");
+}
+
+#[test]
+fn profile_with_comments_and_blank_lines_parses_cleanly() {
+    let text = "
+        # top-level comment
+        name = laptop
+        # attach the first project
+        attach = primegrid|ABC   # trailing comment
+        run_mode = auto
+
+        # blank line above
+        gpu_mode = never
+    ";
+    let profile = parse_profile(text).expect("should tolerate comments/whitespace");
+    assert_eq!(profile.name, "laptop");
+    assert_eq!(profile.attach.len(), 1);
+    assert_eq!(profile.attach[0].url, "https://www.primegrid.com/");
+    assert_eq!(profile.run_mode.map(|m| m.as_boinc_tag()), Some("auto"));
+    assert_eq!(profile.gpu_mode.map(|m| m.as_boinc_tag()), Some("never"));
+}
+
+#[tokio::test]
+async fn rpc_client_accepts_attach_and_update_calls() {
+    let transport = CountingTransport::new();
+    let mut client = BoincRpcClient::new(Box::new(transport), None);
+    let mut write = boincrs::boinc::api::write::BoincWriteApi::new(&mut client);
+    let _ = write
+        .project_attach("https://www.primegrid.com/", "KEY")
+        .await
+        .expect("attach should succeed");
+    let _ = write
+        .project_update("https://www.primegrid.com/")
+        .await
+        .expect("update should succeed");
+}


### PR DESCRIPTION
Production onboarding is now fast and less error-prone for BOINC projects beyond the original PrimeGrid / Asteroids@home pair.

Templates:
- New `boinc::templates` registry with 10 curated projects (asteroids, einstein, gpugrid, lhc, milkyway, primegrid, rosetta, seti, worldcommunitygrid, yoyo) mapping slug -> canonical master URL, name, summary, and categories.
- `resolve_template` accepts either a slug or a full URL; invalid inputs produce a `TemplateError` listing every known slug as a hint.
- `validate_project_url` rejects obvious typos (missing scheme, no dot in host, whitespace) before they reach the RPC.

Profiles:
- New `boinc::profiles` module defines a tiny `key = value` format bundling attach entries plus CPU/network/GPU run-mode overrides.
- Parser reports the offending line number and key for every error; unknown keys are rejected instead of silently ignored.
- `PresetProfile` round-trips through `to_text` / `parse_profile` and can be loaded/saved via `load_profile` / `save_profile`.

Bootstrap:
- Extended to read `BOINCRS_PROFILE_FILE`, `BOINCRS_ATTACH_TEMPLATES`, the original `BOINCRS_*_ACCOUNT_KEY` shortcuts, and the legacy `BOINCRS_ATTACH_PROJECTS`.
- Entries are deduplicated by URL (first-write-wins); malformed per-entry inputs are surfaced in `BootstrapReport.skipped` instead of aborting the whole bootstrap.
- Profile load failures are fatal via a new `AppError::Config` variant (non-transient), so config bugs remain distinct from RPC flakiness.

Tests, lint, docs:
- 14 new unit tests in `templates.rs` / `profiles.rs` / `bootstrap.rs` plus `tests/bootstrap_templates_tests.rs` covering slug lookup, validation errors, profile round-trip, comment/whitespace tolerance, and a mock-RPC attach flow.
- Rustdoc added to every public item, error-variant field, and private helper in the new modules.
- README, CHANGELOG, `.env.example`, `beta-primegrid-asteroids.md` updated and a new `docs/architecture/project-templates-and-profiles.md` added.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all clean.